### PR TITLE
Use un-optimised build for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
       - run: cabal install --only-dependencies --enable-tests
       # Save time building core code
       - run: cabal configure --disable-optimization
-      - run: cabal build
       - run: cabal test
       - save_cache:
           key: cabal_packages-{{ checksum "Htriple.cabal" }}


### PR DESCRIPTION
Performance&volume testing, when added, should use optimised builds but for actual testing the build time is (currently) the majority of the runtime.

When more tests are added, optimising the executable may be worthwhile again.