### PR TITLE
Convert Atom to a GADT to restrict use of 'Variable' 

### DIFF
--- a/lib/Operation.hs
+++ b/lib/Operation.hs
@@ -2,15 +2,7 @@ module Operation where
 
 import Data.Bits
 
-newtype Sym = S String -- deriving (Show, Eq, Ord)
-  deriving (Eq, Ord)
-instance Show Sym where
-  show (S s) = s
-
-instance Read Sym where
-  readsPrec _p s = [(S h, t)]
-    where
-      (h,t) = break (==' ') s
+type Sym = String
 
 data Instruction
   = T TriOp Sym Sym Sym

--- a/lib/Util.hs
+++ b/lib/Util.hs
@@ -1,7 +1,10 @@
 module Util where
 
+import Prelude hiding (showList)
 import qualified Data.Map as M
 import Data.Map (Map)
+import qualified Data.Set as S
+import Data.Set (Set)
 
 indent :: String -> String
 indent x = unlines $ map ("  "++) $ lines x
@@ -24,6 +27,9 @@ showList :: Show a => [a] -> String
 showList xs = drop (length joiner) $ concatMap (\x->joiner++show x) xs
   where
     joiner = ", "
+
+showSet :: Show a => Set a -> String
+showSet = showList . S.toList
 
 showMap :: (Show a, Show b) => Map a b -> String
 showMap xs = drop (length joiner) $ concatMap (\(k, v)->joiner++show k++k_to_v++show v) $ M.toList xs

--- a/test/Core.hs
+++ b/test/Core.hs
@@ -18,6 +18,7 @@ import qualified Data.Set as S
 tests :: IO [Test]
 tests = return $ map Test testList
 
+pred3 :: Atom a -> Atom a -> Atom a -> Pred a
 pred3 r x y = toPred [("#0", x), ("rel", r), ("#1", y)]
 
 -- Constants
@@ -26,11 +27,10 @@ a = val "a"
 b = val "b"
 c = val "c"
 ret = val "ret"
-pa = S "a"
-pb = S "b"
-pRet = S "ret"
+pa = "a"
+pb = "b"
+pRet = "ret"
 ne = val "!="
-ne' :: Atom -> Atom -> Pred
 ne' = pred3 ne
 cons = val "cons"
 nil = val "nil"
@@ -44,11 +44,11 @@ minus = func [T Sub pa pb pRet] (S.fromList [exists a, exists b]) $ S.fromList [
 needsRet = addPre (exists ret) emp
 
 x = var "x"
-px = S "x"
+px = "x"
 y = var "y"
-py = S "y"
+py = "y"
 z = var "z"
-pz = S "z"
+pz = "z"
 isa = val "isa"
 isa' = pred3 isa
 
@@ -139,15 +139,15 @@ resolutionTests
       $ solutions (S.fromList [exists a, exists ne, exists zero])
         $ S.fromList [varXNeZero]
   , mkTest "Resolution succeeds on 1-pred with variable (with matches)"
-      (hasSingleSolution [(px, a)])
+      (hasSingleSolution [(x, a)])
       $ solutions (S.fromList [exists a, aNeZero])
         $ S.fromList [varXNeZero]
   , mkTest "Resolution correct on 1-pred with variable (with alternate matches)"
-      (hasSingleSolution [(px, a)])
+      (hasSingleSolution [(x, a)])
       $ solutions (S.fromList [exists a, exists b, aNeZero])
         $ S.fromList [varXNeZero]
   , mkTest "Resolution correct on 1-pred with variable"
-      (hasSingleSolution [(px, a), (py, b)])
+      (hasSingleSolution [(x, a), (y, b)])
       $ solutions (S.fromList [exists a, exists b, aNeb])
         $ S.fromList [xNeY]
   , mkTest "Resolution fails on 1-pred with variable"
@@ -172,15 +172,15 @@ resolutionTests
       $ solutions (S.fromList [pred3 isa a b])
         $ S.fromList [pred3 isa x y, pred3 isa y z]
   , mkTest "Resolution correct on 2-pred with variable"
-      (hasSingleSolution [(pz, c), (px, a), (py, b)])
+      (hasSingleSolution [(z, c), (x, a), (y, b)])
       $ solutions (S.fromList [pred3 isa a b, pred3 isa b c])
         $ S.fromList [pred3 isa x y, pred3 isa y z]
   , mkTest "Resolution correct on pattern matched nested 1-pred"
-      (hasSingleSolution [(px, a), (py, b)])
+      (hasSingleSolution [(x, a), (y, b)])
       $ solutions (S.fromList [pred3 isa (Predicate $ pred3 cons a b) list])
         $ S.fromList [pred3 isa (Predicate $ pred3 cons x y) list]
   , mkTest "Resolution correct on nested 1-pred"
-      (hasSingleSolution [(S "x.#0", a), (S "x.rel", cons), (S "x.#1", b)])
+      (hasSingleSolution [(var "x.#0", a), (var "x.rel", cons), (var "x.#1", b)])
       -- (==[[(x, Predicate [a, cons, b])]])
       $ solutions (S.fromList [pred3 isa (Predicate $pred3 cons a b) list])
         $ S.fromList [pred3 isa x list]

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -9,7 +9,7 @@ import Debug.Trace
 import Data.Either (isLeft, isRight)
 import qualified Data.Map as M
 
-import Pred (Assignment, Atom)
+import Pred (Assignment, Atom, Var, Val)
 import Operation (Sym)
 
 -- Test types
@@ -19,16 +19,16 @@ prints = (/= "").show
 debug :: a -> Bool
 debug = const False
 
-hasNoSolution :: [Assignment] -> Bool
+hasNoSolution :: Eq (Assignment a) => [Assignment a] -> Bool
 hasNoSolution = (==[])
 
-hasEmptySolution :: [Assignment] -> Bool
+hasEmptySolution :: Eq (Assignment a) => [Assignment a] -> Bool
 hasEmptySolution = (==[mempty])
 
-hasSingleSolution :: [(Sym, Atom)] -> [Assignment] -> Bool
+hasSingleSolution :: [(Atom Var, Atom Val)] -> [Assignment Val] -> Bool
 hasSingleSolution req = hasOnlySolutions [req]
 
-hasOnlySolutions :: [[(Sym, Atom)]] -> [Assignment] -> Bool
+hasOnlySolutions :: [[(Atom Var, Atom Val)]] -> [Assignment Val] -> Bool
 hasOnlySolutions reqs = (==)(map M.fromList reqs)
 
 mkTest :: Show a => String -> (a -> Bool) -> a -> [String]-> TestInstance


### PR DESCRIPTION
Replaces Atom with Atom a where a is either Val or Var.
Atom Val is the type of Atoms that are 'concrete', there are no
variables, all the values are statically known.
Atom Var is the type of Atoms that may not be concrete. This includes
variables and predicates with variables in them.

Note: Rules, when added, will be Atom Val (they are concrete) but they
contain a set of Atom Var (they are general, but do not need to be
resolved until they are applied).
Rules may need two forms for quantification: Forall, Exists.