### PR TITLE
Attach solver to parser

### DIFF
--- a/examples/t1.htr
+++ b/examples/t1.htr
@@ -1,3 +1,3 @@
-c={
+c(x,y,z)={
   a=b(m = n(), -{hasIO}o+{didIO})
 }

--- a/lib/Triple.hs
+++ b/lib/Triple.hs
@@ -20,14 +20,11 @@ import           Resolution                     ( State
 import           Operation                      ( Op )
 import qualified Data.Set                      as S
 
-data Triple a b c= Tri
-  { pre :: a  -- requirements of the calling environment
-  , op :: b   -- operations to be executed
-  , post :: c -- outcomes of the operations
-  } deriving (Eq, Ord, Show)
-
-type HTriple = Triple Requirements Op State -- HTriples are triples over operations, with states/checks
--- TODO(jopra): Consider new typing pre vs post conditions to ensure they aren't mixed up
+data HTriple = Tri {
+  pre :: Requirements, -- requirements of the calling environment
+  op :: Op, -- operations to be executed
+  post :: State -- state the outcomes of the operations
+} deriving (Eq, Ord, Show)
 
 instance Pretty HTriple where
   pretty t = "{"++pre'++"}"++prettyList op'++"{"++post'++"}"

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -23,4 +23,4 @@ parsesExamples =
 parsesExample :: String -> TestTree
 parsesExample file = testCase ("Can parse example file(" ++ file ++ ")") $ do
   parsed <- parseFile file
-  assertBool (show parsed) (and $ zipWith (==) "Scope [" (show parsed))
+  assertBool (show parsed) (and $ zipWith (==) "Scope " (show parsed))


### PR DESCRIPTION
Initial work to merge the parser AST node definitions with the data used in the solver so that the solver can work on parsed output.