### PR TITLE
Disable wasm buildAll test (wasm builds require building wabt tooling…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,9 @@ jobs:
       run: cargo build --release --verbose
     - name: Run tests
       run: cargo test --release --verbose
-    - name: Compile examples via wasm
-      if: runner.os == 'Linux'
-      run: cd wasm && ./buildAll.sh
+      # - name: Compile examples via wasm
+      # if: runner.os == 'Linux'
+      # run: cd wasm && ./buildAll.sh
     - name: Upload executable Linux
       if: runner.os == 'Linux'
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
… which is slow and wasm is no longer the primary target)