### PR TITLE
Pass context in Eval Request for interpreter variable changes

### DIFF
--- a/tako/src/ui/http.rs
+++ b/tako/src/ui/http.rs
@@ -1,9 +1,11 @@
 use crate::cli_options::{Options, TITLE, VERSION};
 use async_trait::async_trait;
 use log::debug;
+use takolib::ast::Ast;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use takolib::primitives::Prim;
 use takolib::tasks::RequestTask;
@@ -47,9 +49,10 @@ async fn run_server(request_sender: mpsc::UnboundedSender<CompilerRequest>) {
             let request_sender = request_sender.clone();
             async move {
                 let (tx, mut rx) = mpsc::unbounded_channel();
+                let ast = Ast::new(PathBuf::from("interpreter.tk"));
                 request_sender
                     .send(CompilerRequest::RequestTask(
-                        RequestTask::Eval(line.to_string()),
+                        RequestTask::Eval { ast, expr: line.to_string()},
                         client_id,
                         tx,
                     ))

--- a/tako/src/ui/http.rs
+++ b/tako/src/ui/http.rs
@@ -49,7 +49,7 @@ async fn run_server(request_sender: mpsc::UnboundedSender<CompilerRequest>) {
                 let (tx, mut rx) = mpsc::unbounded_channel();
                 request_sender
                     .send(CompilerRequest::RequestTask(
-                        RequestTask::EvalLine(line.to_string()),
+                        RequestTask::Eval(line.to_string()),
                         client_id,
                         tx,
                     ))

--- a/tako/src/ui/http.rs
+++ b/tako/src/ui/http.rs
@@ -1,12 +1,12 @@
 use crate::cli_options::{Options, TITLE, VERSION};
 use async_trait::async_trait;
 use log::debug;
-use takolib::ast::Ast;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
+use takolib::ast::Ast;
 use takolib::primitives::Prim;
 use takolib::tasks::RequestTask;
 use takolib::ui::OptionsTrait;
@@ -49,10 +49,13 @@ async fn run_server(request_sender: mpsc::UnboundedSender<CompilerRequest>) {
             let request_sender = request_sender.clone();
             async move {
                 let (tx, mut rx) = mpsc::unbounded_channel();
-                let ast = Ast::new(PathBuf::from("interpreter.tk"));
+                let ast = Some(Ast::new(PathBuf::from("interpreter.tk")));
                 request_sender
                     .send(CompilerRequest::RequestTask(
-                        RequestTask::Eval { ast, expr: line.to_string()},
+                        RequestTask::Eval {
+                            ast,
+                            expr: line.to_string(),
+                        },
                         client_id,
                         tx,
                     ))

--- a/tako/src/ui/tui.rs
+++ b/tako/src/ui/tui.rs
@@ -12,10 +12,12 @@ use futures::{future::FutureExt, StreamExt};
 use log::trace;
 use shutdown_hooks::add_shutdown_hook;
 use std::{
-    io::{Write, stdout}, path::PathBuf, time::{Duration, Instant}
+    io::{stdout, Write},
+    path::PathBuf,
+    time::{Duration, Instant},
 };
-use takolib::{ast::Ast, tasks::RequestTask};
 use takolib::ui::{Client, OptionsTrait, UserInterface};
+use takolib::{ast::Ast, tasks::RequestTask};
 use tokio::{
     sync::{mpsc, oneshot},
     time,
@@ -168,9 +170,11 @@ impl Tui {
                         line += &self.input_after_cursor;
                         if !line.is_empty() {
                             trace!("Running {line}");
-                            let ast = Ast::new(PathBuf::from("interpreter.tk"));
-                            self.client
-                                .send_command(RequestTask::Eval{ ast, expr: line.to_string()});
+                            let ast = Some(Ast::new(PathBuf::from("interpreter.tk")));
+                            self.client.send_command(RequestTask::Eval {
+                                ast,
+                                expr: line.to_string(),
+                            });
                         }
                         self.input_after_cursor = String::new();
                     }

--- a/tako/src/ui/tui.rs
+++ b/tako/src/ui/tui.rs
@@ -12,10 +12,9 @@ use futures::{future::FutureExt, StreamExt};
 use log::trace;
 use shutdown_hooks::add_shutdown_hook;
 use std::{
-    io::{stdout, Write},
-    time::{Duration, Instant},
+    io::{Write, stdout}, path::PathBuf, time::{Duration, Instant}
 };
-use takolib::tasks::RequestTask;
+use takolib::{ast::Ast, tasks::RequestTask};
 use takolib::ui::{Client, OptionsTrait, UserInterface};
 use tokio::{
     sync::{mpsc, oneshot},
@@ -169,8 +168,9 @@ impl Tui {
                         line += &self.input_after_cursor;
                         if !line.is_empty() {
                             trace!("Running {line}");
+                            let ast = Ast::new(PathBuf::from("interpreter.tk"));
                             self.client
-                                .send_command(RequestTask::Eval(line.to_string()));
+                                .send_command(RequestTask::Eval{ ast, expr: line.to_string()});
                         }
                         self.input_after_cursor = String::new();
                     }

--- a/tako/src/ui/tui.rs
+++ b/tako/src/ui/tui.rs
@@ -170,7 +170,7 @@ impl Tui {
                         if !line.is_empty() {
                             trace!("Running {line}");
                             self.client
-                                .send_command(RequestTask::EvalLine(line.to_string()));
+                                .send_command(RequestTask::Eval(line.to_string()));
                         }
                         self.input_after_cursor = String::new();
                     }

--- a/takolib/src/ast/mod.rs
+++ b/takolib/src/ast/mod.rs
@@ -7,15 +7,16 @@ pub mod location;
 mod pretty_printer;
 pub mod string_interner;
 
-use crate::parser::semantics::Literal;
+use crate::{parser::semantics::Literal, primitives::Prim};
 use crate::parser::tokens::Symbol;
 use crate::primitives::typed_index::TypedIndex;
 use location::Location;
 use pretty_printer::{pretty, pretty_node};
 use smallvec::smallvec;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use string_interner::{Identifier, StringInterner};
+use string_interner::{Name, StringInterner};
 
 type Container<T> = Arc<Vec<T>>;
 
@@ -32,13 +33,14 @@ pub struct Ast {
 
     // Syntactic constructs:
     pub calls: Container<(NodeId, Call)>, // Convert to this from definition head.
-    pub identifiers: Container<(NodeId, Identifier)>, // Convert to this from definition head.
+    pub identifiers: Container<(NodeId, Name)>, // Convert to this from definition head.
     pub ops: Container<(NodeId, Op)>,
     pub definitions: Container<(NodeId, Definition)>,
     pub literals: Container<(NodeId, Literal)>,
     pub atoms: Container<(NodeId, Atom)>,
 
     pub string_interner: StringInterner,
+    pub name_to_value: BTreeMap<Name, Prim>,
 }
 
 impl Ast {

--- a/takolib/src/ast/mod.rs
+++ b/takolib/src/ast/mod.rs
@@ -7,9 +7,9 @@ pub mod location;
 mod pretty_printer;
 pub mod string_interner;
 
-use crate::{parser::semantics::Literal, primitives::Prim};
 use crate::parser::tokens::Symbol;
 use crate::primitives::typed_index::TypedIndex;
+use crate::{parser::semantics::Literal, primitives::Prim};
 use location::Location;
 use pretty_printer::{pretty, pretty_node};
 use smallvec::smallvec;

--- a/takolib/src/ast/nodes.rs
+++ b/takolib/src/ast/nodes.rs
@@ -1,7 +1,7 @@
 use super::contains::Contains;
 use super::location::Location;
 use super::Ast;
-use crate::ast::string_interner::Identifier;
+use crate::ast::string_interner::Name;
 use crate::parser::{
     semantics::{BindingMode, Literal},
     tokens::Symbol,
@@ -45,7 +45,7 @@ pub enum NodeData {
 
 make_contains!(
     identifiers,
-    (NodeId, Identifier),
+    (NodeId, Name),
     Identifier,
     IdentifierId,
     add_identifier
@@ -64,7 +64,7 @@ make_contains!(warnings, (NodeId, Warning), Warning, WarningId, add_warning);
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Atom {
-    pub name: Identifier,
+    pub name: Name,
 }
 make_contains!(atoms, (NodeId, Atom), Atom, AtomId, add_atom);
 
@@ -107,7 +107,7 @@ impl Op {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Definition {
     pub mode: BindingMode,
-    pub name: Identifier,
+    pub name: Name,
     pub bindings: Option<SmallVec<NodeId, 2>>,
     pub implementation: Option<NodeId>,
 }

--- a/takolib/src/ast/pretty_printer.rs
+++ b/takolib/src/ast/pretty_printer.rs
@@ -1,5 +1,5 @@
 #![allow(unused)]
-use crate::ast::{string_interner::Identifier, Ast, Contains, Definition, Node, NodeData, NodeId};
+use crate::ast::{string_interner::Name, Ast, Contains, Definition, Node, NodeData, NodeId};
 use crate::parser::semantics::BindingMode;
 use better_std::as_context;
 use smallvec::SmallVec;
@@ -33,7 +33,7 @@ impl PrintNode<'_> {
         &self,
         f: &mut fmt::Formatter<'_>,
         mode: BindingMode,
-        name: Identifier,
+        name: Name,
         bindings: Option<T>,
         ty: &mut Option<NodeId>,
     ) -> fmt::Result {
@@ -72,7 +72,7 @@ impl PrintNode<'_> {
         self.print_ty(f, ty)
     }
 
-    fn print_identifier(&self, f: &mut fmt::Formatter<'_>, ident: Identifier) -> fmt::Result {
+    fn print_identifier(&self, f: &mut fmt::Formatter<'_>, ident: Name) -> fmt::Result {
         let s = self.context().string_interner.get_str(ident);
         if let Some(s) = s {
             write!(f, "{s}")

--- a/takolib/src/ast/pretty_printer.rs
+++ b/takolib/src/ast/pretty_printer.rs
@@ -223,7 +223,7 @@ mod tests {
     fn setup(s: &str) -> Result<String, TError> {
         crate::ensure_initialized();
         let tokens = lex(s)?;
-        let ast = parse(&test_file1(), s, &tokens)?;
+        let ast = parse(&test_file1(), &None, s, &tokens)?;
         assert_eq!(
             ast.roots.len(),
             1,

--- a/takolib/src/ast/string_interner.rs
+++ b/takolib/src/ast/string_interner.rs
@@ -10,11 +10,11 @@ use std::sync::Arc;
 type StringHash = u64;
 // Ensures that str ids are unique per string but also stable across different files etc.
 pub type StrId = TypedIndex<String, StringHash>;
-pub type Identifier = StrId;
+pub type Name = StrId;
 
 use static_assertions::assert_eq_size;
-assert_eq_size!(Identifier, [u8; 8]);
-assert_eq_size!([Identifier; 2], [u8; 16]);
+assert_eq_size!(Name, [u8; 8]);
+assert_eq_size!([Name; 2], [u8; 16]);
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct StringInterner {

--- a/takolib/src/compiler.rs
+++ b/takolib/src/compiler.rs
@@ -200,7 +200,13 @@ impl Compiler {
         let (tx2, rx2) = mpsc::unbounded_channel();
         spawn(async move {
             // TODO: Use a proper map from in paths to out paths.
-            while let Some(ParseFileTask { path, ast: _not_populated, contents, tokens }) = rx1.recv().await {
+            while let Some(ParseFileTask {
+                path,
+                ast: _not_populated,
+                contents,
+                tokens,
+            }) = rx1.recv().await
+            {
                 tx2.send(ParseFileTask {
                     path,
                     ast: og_ast.clone(),
@@ -238,7 +244,12 @@ impl Compiler {
         let (tx2, rx2) = mpsc::unbounded_channel();
         spawn(async move {
             // TODO: Use a proper map from in paths to out paths.
-            while let Some(EvalFileTask { path: new_path, ast: new_ast, root }) = rx1.recv().await {
+            while let Some(EvalFileTask {
+                path: new_path,
+                ast: new_ast,
+                root,
+            }) = rx1.recv().await
+            {
                 let Some(root) = root else {
                     todo!("No known root!?")
                 };
@@ -328,7 +339,13 @@ impl Compiler {
                     let ast = Some(Ast::new(file.to_path_buf()));
                     let mut file_with_extension = file.clone();
                     file_with_extension.set_extension("out");
-                    self.codegen(file, ast, file_with_extension, None, response_sender.clone());
+                    self.codegen(
+                        file,
+                        ast,
+                        file_with_extension,
+                        None,
+                        response_sender.clone(),
+                    );
                 }
             }
             RequestTask::RunInterpreter { files } => {

--- a/takolib/src/compiler.rs
+++ b/takolib/src/compiler.rs
@@ -190,21 +190,33 @@ impl Compiler {
 
     pub fn parse(
         &self,
-        path: PathBuf,
-        ast: Ast,
-        contents: Option<String>,
+        og_path: PathBuf,
+        og_ast: Option<Ast>,
+        og_contents: Option<String>,
         response_sender: ResultSenderFor<ParseFileTask>,
     ) {
-        let (tx, rx) = mpsc::unbounded_channel();
-        self.lex(path, contents, tx);
-        // TODO: Add the `ast` to the `rx`.
-        Self::with_manager(rx, &self.parse_file_manager, response_sender);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
+        self.lex(og_path, og_contents, tx1);
+        let (tx2, rx2) = mpsc::unbounded_channel();
+        spawn(async move {
+            // TODO: Use a proper map from in paths to out paths.
+            while let Some(ParseFileTask { path, ast: _not_populated, contents, tokens }) = rx1.recv().await {
+                tx2.send(ParseFileTask {
+                    path,
+                    ast: og_ast.clone(),
+                    contents,
+                    tokens,
+                })
+                .expect("Should be able to send codegen task");
+            }
+        });
+        Self::with_manager(rx2, &self.parse_file_manager, response_sender);
     }
 
     pub fn desugar(
         &self,
         path: PathBuf,
-        ast: Ast,
+        ast: Option<Ast>,
         contents: Option<String>,
         response_sender: ResultSenderFor<DesugarFileTask>,
     ) {
@@ -216,7 +228,7 @@ impl Compiler {
     pub fn lower(
         &self,
         og_path: PathBuf,
-        og_ast: Ast,
+        og_ast: Option<Ast>,
         contents: Option<String>,
         response_sender: ResultSenderFor<LowerFileTask>,
     ) {
@@ -244,7 +256,7 @@ impl Compiler {
     pub fn eval(
         &self,
         path: PathBuf,
-        ast: Ast,
+        ast: Option<Ast>,
         contents: Option<String>,
         response_sender: ResultSenderFor<EvalFileTask>,
     ) {
@@ -256,7 +268,7 @@ impl Compiler {
     pub fn codegen(
         &self,
         path: PathBuf,
-        og_ast: Ast,
+        og_ast: Option<Ast>,
         out_path: PathBuf,
         contents: Option<String>,
         response_sender: ResultSenderFor<CodegenTask>,
@@ -313,7 +325,7 @@ impl Compiler {
             }
             RequestTask::Build { files } => {
                 for file in files {
-                    let ast = Ast::new(file.to_path_buf());
+                    let ast = Some(Ast::new(file.to_path_buf()));
                     let mut file_with_extension = file.clone();
                     file_with_extension.set_extension("out");
                     self.codegen(file, ast, file_with_extension, None, response_sender.clone());
@@ -322,8 +334,7 @@ impl Compiler {
             RequestTask::RunInterpreter { files } => {
                 for file in files {
                     // TODO(cypher1): Support context / imports.
-                    //
-                    let ast = Ast::new(file.to_path_buf());
+                    let ast = Some(Ast::new(file.to_path_buf()));
                     self.eval(file, ast, None, response_sender.clone());
                 }
             }

--- a/takolib/src/compiler.rs
+++ b/takolib/src/compiler.rs
@@ -1,4 +1,5 @@
 use super::ui::OptionsTrait;
+use crate::ast::Ast;
 use crate::primitives::meta::Meta;
 use crate::primitives::Prim;
 use crate::tasks::manager::TaskManager;
@@ -190,44 +191,48 @@ impl Compiler {
     pub fn parse(
         &self,
         path: PathBuf,
+        ast: Ast,
         contents: Option<String>,
         response_sender: ResultSenderFor<ParseFileTask>,
     ) {
         let (tx, rx) = mpsc::unbounded_channel();
         self.lex(path, contents, tx);
+        // TODO: Add the `ast` to the `rx`.
         Self::with_manager(rx, &self.parse_file_manager, response_sender);
     }
 
     pub fn desugar(
         &self,
         path: PathBuf,
+        ast: Ast,
         contents: Option<String>,
         response_sender: ResultSenderFor<DesugarFileTask>,
     ) {
         let (tx, rx) = mpsc::unbounded_channel();
-        self.parse(path, contents, tx);
+        self.parse(path, ast, contents, tx);
         Self::with_manager(rx, &self.desugar_file_manager, response_sender);
     }
 
     pub fn lower(
         &self,
-        path: PathBuf,
+        og_path: PathBuf,
+        og_ast: Ast,
         contents: Option<String>,
         response_sender: ResultSenderFor<LowerFileTask>,
     ) {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         // TODO: Static checking should be here.
-        self.desugar(path.clone(), contents, tx1);
+        self.desugar(og_path.clone(), og_ast, contents, tx1);
         let (tx2, rx2) = mpsc::unbounded_channel();
         spawn(async move {
             // TODO: Use a proper map from in paths to out paths.
-            while let Some(EvalFileTask { path: _, ast, root }) = rx1.recv().await {
+            while let Some(EvalFileTask { path: new_path, ast: new_ast, root }) = rx1.recv().await {
                 let Some(root) = root else {
                     todo!("No known root!?")
                 };
                 tx2.send(LowerFileTask {
-                    path: path.clone(),
-                    ast: ast.clone(),
+                    path: new_path.clone(),
+                    ast: new_ast.clone(),
                     root,
                 })
                 .expect("Should be able to send codegen task");
@@ -239,24 +244,26 @@ impl Compiler {
     pub fn eval(
         &self,
         path: PathBuf,
+        ast: Ast,
         contents: Option<String>,
         response_sender: ResultSenderFor<EvalFileTask>,
     ) {
         let (tx, rx) = mpsc::unbounded_channel();
-        self.desugar(path, contents, tx);
+        self.desugar(path, ast, contents, tx);
         Self::with_manager(rx, &self.eval_file_manager, response_sender);
     }
 
     pub fn codegen(
         &self,
         path: PathBuf,
+        og_ast: Ast,
         out_path: PathBuf,
         contents: Option<String>,
         response_sender: ResultSenderFor<CodegenTask>,
     ) {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         // TODO: Static checking should be here.
-        self.lower(path, contents, tx1);
+        self.lower(path, og_ast, contents, tx1);
         let (tx2, rx2) = mpsc::unbounded_channel();
         spawn(async move {
             // TODO: Use a proper map from in paths to out paths.
@@ -269,7 +276,7 @@ impl Compiler {
             {
                 tx2.send(CodegenTask {
                     path: out_path.clone(),
-                    ast: ast.clone(),
+                    ast,
                     lowered: lowered.clone(),
                     root,
                 })
@@ -300,19 +307,24 @@ impl Compiler {
 
     pub fn start_command(&self, cmd: RequestTask, response_sender: mpsc::UnboundedSender<Prim>) {
         match cmd {
-            RequestTask::EvalLine(line) => {
-                self.eval("interpreter.tk".into(), Some(line), response_sender);
+            RequestTask::Eval { ast, expr } => {
+                // TODO(cypher1): Inject previous context into the eval state here.
+                self.eval("interpreter.tk".into(), ast, Some(expr), response_sender);
             }
             RequestTask::Build { files } => {
                 for file in files {
+                    let ast = Ast::new(file.to_path_buf());
                     let mut file_with_extension = file.clone();
                     file_with_extension.set_extension("out");
-                    self.codegen(file, file_with_extension, None, response_sender.clone());
+                    self.codegen(file, ast, file_with_extension, None, response_sender.clone());
                 }
             }
             RequestTask::RunInterpreter { files } => {
                 for file in files {
-                    self.eval(file, None, response_sender.clone());
+                    // TODO(cypher1): Support context / imports.
+                    //
+                    let ast = Ast::new(file.to_path_buf());
+                    self.eval(file, ast, None, response_sender.clone());
                 }
             }
         }

--- a/takolib/src/desugarer/mod.rs
+++ b/takolib/src/desugarer/mod.rs
@@ -69,7 +69,7 @@ mod tests {
     fn setup(s: &str) -> Result<Ast, TError> {
         crate::ensure_initialized();
         let tokens = lex(s)?;
-        let ast = parse(&test_path(), s, &tokens)?;
+        let ast = parse(&test_path(), &None, s, &tokens)?;
         Ok(ast)
     }
 

--- a/takolib/src/interpreter.rs
+++ b/takolib/src/interpreter.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::path::Path;
 
-
 #[derive(Default, Clone, Debug, Eq, PartialEq)]
 pub struct State {
     names: HashMap<Name, Prim>,
@@ -51,9 +50,7 @@ pub fn run_impl(path: &Path, mut ast: Ast, root: Option<NodeId>) -> Result<(Ast,
             location: None,
         });
     };
-    let mut ctx = Ctx {
-        ast: &mut ast
-    };
+    let mut ctx = Ctx { ast: &mut ast };
     let result = ctx.eval(start)?;
     Ok((ctx.ast.clone(), result)) // TODO: No need to copy here
 }
@@ -295,13 +292,13 @@ mod tests {
     fn setup(s: &str) -> Result<Ast, TError> {
         crate::ensure_initialized();
         let tokens = lex(s)?;
-        parse(&test_path(), s, &tokens)
+        parse(&test_path(), &None, s, &tokens)
     }
 
     #[test]
     fn literal_evals_to_itself() -> Result<(), TError> {
         let ast = setup("123")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(123)));
         Ok(())
     }
@@ -309,7 +306,7 @@ mod tests {
     #[test]
     fn literal_negatives_multiply_out() -> Result<(), TError> {
         let ast = setup("-3*-2")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(6)));
         Ok(())
     }
@@ -325,7 +322,7 @@ mod tests {
     #[test]
     fn exp_exp_evals_512() -> Result<(), TError> {
         let ast = setup("2**3**2")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(512)));
         Ok(())
     }
@@ -333,7 +330,7 @@ mod tests {
     #[test]
     fn exp_var_and_use() -> Result<(), TError> {
         let ast = setup("x=2;x")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(2)));
         Ok(())
     }
@@ -341,7 +338,7 @@ mod tests {
     #[test]
     fn exp_var_from_expr_and_use() -> Result<(), TError> {
         let ast = setup("x=3+2;x")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(5)));
         Ok(())
     }
@@ -349,7 +346,7 @@ mod tests {
     #[test]
     fn exp_nested_vars() -> Result<(), TError> {
         let ast = setup("x=(y=3;2*y);x")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(6)));
         Ok(())
     }
@@ -357,7 +354,7 @@ mod tests {
     #[test]
     fn exp_multiple_statements() -> Result<(), TError> {
         let ast = setup("x=3;y=x+4;2*y")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(14)));
         Ok(())
     }
@@ -365,7 +362,7 @@ mod tests {
     #[test]
     fn exp_multiple_statements_as_lambdas() -> Result<(), TError> {
         let ast = setup("(x->(y->(2*y))(y=x+4))(x=3)")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(14)));
         Ok(())
         // TODO: Remove!

--- a/takolib/src/interpreter.rs
+++ b/takolib/src/interpreter.rs
@@ -11,12 +11,12 @@ use std::path::Path;
 
 type Name = StrId;
 
-#[derive(Default, Clone, Debug)]
-struct State {
+#[derive(Default, Clone, Debug, Eq, PartialEq)]
+pub struct State {
     names: HashMap<Name, Prim>,
 }
 
-impl State {
+impl Ast {
     fn get_binding(&self, name: &Name) -> Option<&Prim> {
         self.names.get(name)
     }
@@ -25,10 +25,9 @@ impl State {
 struct Ctx<'a> {
     ast: &'a Ast,
     literals: &'a StringInterner,
-    state: State,
 }
 
-pub fn run(path: &Path, ast: &Ast, root: Option<NodeId>) -> Result<Prim, TError> {
+pub fn run(path: &Path, ast: &Ast, root: Option<NodeId>) -> Result<(Ast, Prim), TError> {
     let start = if let Some(root) = root {
         root
     } else if ast.roots.len() == 1 {
@@ -53,9 +52,9 @@ pub fn run(path: &Path, ast: &Ast, root: Option<NodeId>) -> Result<Prim, TError>
     let mut ctx = Ctx {
         ast,
         literals: &ast.string_interner,
-        state: State::default(),
     };
-    ctx.eval(start)
+    let result = ctx.eval(start)?;
+    Ok((ctx.ast.clone(), result)) // TODO: No need to copy here
 }
 
 impl Ctx<'_> {
@@ -75,7 +74,7 @@ impl Ctx<'_> {
             NodeData::NodeRef(_id) => todo!(),
             NodeData::Identifier(ident) => {
                 let (_id, name) = self.ast.get(ident);
-                let Some(value) = self.state.get_binding(name) else {
+                let Some(value) = self.ast.get_binding(name) else {
                     let Some(name) = self.ast.string_interner.get_str(*name) else {
                         panic!("Not found (unknown name): {name:?}");
                     };
@@ -106,7 +105,7 @@ impl Ctx<'_> {
                     None => {
                         let value =
                             self.eval(implementation.expect("Should have implementation"))?;
-                        self.state.names.insert(*name, value);
+                        self.ast.names.insert(*name, value);
                         Ok(Prim::Unit)
                     }
                     _ => todo!("Handle a binding with: {name:?}, {bindings:?}, {implementation:?}"),

--- a/takolib/src/interpreter.rs
+++ b/takolib/src/interpreter.rs
@@ -1,4 +1,4 @@
-use crate::ast::string_interner::{StrId, StringInterner};
+use crate::ast::string_interner::Name;
 use crate::ast::{Ast, Call, Contains, Definition, LiteralId, Node, NodeData, NodeId, OpId};
 use crate::error::TError;
 use crate::parser::semantics::Literal;
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::path::Path;
 
-type Name = StrId;
 
 #[derive(Default, Clone, Debug, Eq, PartialEq)]
 pub struct State {
@@ -18,16 +17,19 @@ pub struct State {
 
 impl Ast {
     fn get_binding(&self, name: &Name) -> Option<&Prim> {
-        self.names.get(name)
+        self.name_to_value.get(name)
     }
 }
 
 struct Ctx<'a> {
-    ast: &'a Ast,
-    literals: &'a StringInterner,
+    ast: &'a mut Ast, // Allowing computed values to be updated in `name_to_value`.
 }
 
-pub fn run(path: &Path, ast: &Ast, root: Option<NodeId>) -> Result<(Ast, Prim), TError> {
+pub fn run(path: &Path, ast: Ast, root: Option<NodeId>) -> Result<Prim, TError> {
+    let (_, result) = run_impl(path, ast, root)?;
+    Ok(result)
+}
+pub fn run_impl(path: &Path, mut ast: Ast, root: Option<NodeId>) -> Result<(Ast, Prim), TError> {
     let start = if let Some(root) = root {
         root
     } else if ast.roots.len() == 1 {
@@ -50,8 +52,7 @@ pub fn run(path: &Path, ast: &Ast, root: Option<NodeId>) -> Result<(Ast, Prim), 
         });
     };
     let mut ctx = Ctx {
-        ast,
-        literals: &ast.string_interner,
+        ast: &mut ast
     };
     let result = ctx.eval(start)?;
     Ok((ctx.ast.clone(), result)) // TODO: No need to copy here
@@ -69,7 +70,7 @@ impl Ctx<'_> {
     pub fn eval(&mut self, node: NodeId) -> Result<Prim, TError> {
         trace!("Eval: {}", self.ast.pretty_node(node));
         // TODO(core): implement evaluation of the AST
-        let node = node.get(&self.ast.nodes);
+        let node = node.get(&self.ast.nodes).clone();
         match node.id {
             NodeData::NodeRef(_id) => todo!(),
             NodeData::Identifier(ident) => {
@@ -84,13 +85,13 @@ impl Ctx<'_> {
             }
             NodeData::Atom(_id) => todo!(),
             NodeData::Call(call) => {
-                let (_id, Call { inner, args }) = self.ast.get(call);
+                let (_id, Call { inner, args }) = self.ast.get(call).clone();
                 for arg in args.iter() {
                     self.eval(*arg)?;
                 }
-                self.eval(*inner)
+                self.eval(inner)
             }
-            NodeData::Op(id) => self.eval_op(node, id),
+            NodeData::Op(id) => self.eval_op(&node, id),
             NodeData::Definition(def) => {
                 let (
                     _id,
@@ -100,24 +101,24 @@ impl Ctx<'_> {
                         bindings,
                         implementation,
                     },
-                ) = self.ast.get(def);
+                ) = self.ast.get(def).clone();
                 match bindings {
                     None => {
                         let value =
                             self.eval(implementation.expect("Should have implementation"))?;
-                        self.ast.names.insert(*name, value);
+                        self.ast.name_to_value.insert(name, value);
                         Ok(Prim::Unit)
                     }
                     _ => todo!("Handle a binding with: {name:?}, {bindings:?}, {implementation:?}"),
                 }
             }
-            NodeData::Literal(id) => self.eval_lit(node, id),
+            NodeData::Literal(id) => self.eval_lit(&node, id),
             NodeData::Warning(_id) => todo!(),
         }
     }
     pub fn eval_lit(&mut self, node: &Node, id: LiteralId) -> Result<Prim, TError> {
         let (_node_id, lit) = id.get(&self.ast.literals);
-        let s = self.literals.get_str_by_loc(node.location.start);
+        let s = self.ast.string_interner.get_str_by_loc(node.location.start);
         Ok(match lit {
             Literal::Bool => todo!("{lit:?} {s:?}"),
             Literal::Numeric => {
@@ -130,7 +131,7 @@ impl Ctx<'_> {
         })
     }
     pub fn eval_op(&mut self, _node: &Node, id: OpId) -> Result<Prim, TError> {
-        let (_node_id, op) = id.get(&self.ast.ops);
+        let (_node_id, op) = id.get(&self.ast.ops).clone(); // TODO: Consider making these `Copy`.
         Ok(match op.op {
             Symbol::Add => match self.eval2(&op.args)? {
                 [Prim::I32(l), Prim::I32(r)] => Prim::I32(l + r),
@@ -316,7 +317,7 @@ mod tests {
     #[test]
     fn exp_mul_evals_16() -> Result<(), TError> {
         let ast = setup("2**3*2")?;
-        let res = run(&test_path(), &ast, None);
+        let res = run(&test_path(), ast, None);
         assert_eq!(res, Ok(Prim::I32(16)));
         Ok(())
     }

--- a/takolib/src/lowerer/mod.rs
+++ b/takolib/src/lowerer/mod.rs
@@ -124,7 +124,7 @@ mod tests {
     fn setup(s: &str) -> Result<Ast, TError> {
         crate::ensure_initialized();
         let tokens = lex(s)?;
-        let ast = parse(&test_path(), s, &tokens)?;
+        let ast = parse(&test_path(), &None, s, &tokens)?;
         Ok(ast)
     }
 

--- a/takolib/src/parser/mod.rs
+++ b/takolib/src/parser/mod.rs
@@ -671,11 +671,16 @@ impl<'toks, T: Iterator<Item = &'toks Token>> ParseState<'_, 'toks, T> {
     }
 }
 
-pub fn parse(filepath: &Path, contents: &str, tokens: &[Token]) -> Result<Ast, TError> {
+pub fn parse(filepath: &Path, ast: &Option<Ast>, contents: &str, tokens: &[Token]) -> Result<Ast, TError> {
     trace!("Parse {}: {:?}", filepath.display(), &tokens);
+    let ast = if let Some(ast) = ast {
+        ast.clone()
+    } else {
+        Ast::new(filepath.to_path_buf())
+    };
     let mut state = ParseState {
         contents,
-        ast: Ast::new(filepath.to_path_buf()),
+        ast,
         tokens: tokens.iter().peekable(),
     };
     if !tokens.is_empty() {

--- a/takolib/src/parser/mod.rs
+++ b/takolib/src/parser/mod.rs
@@ -1,7 +1,7 @@
 pub mod semantics;
 pub mod tokens;
 use crate::ast::location::Location;
-use crate::ast::string_interner::Identifier;
+use crate::ast::string_interner::Name;
 use crate::ast::{Ast, Atom, Call, Contains, Definition, NodeData, NodeId, Op};
 use crate::error::TError;
 use better_std::include_strs;
@@ -140,7 +140,7 @@ impl std::fmt::Display for ParseError {
 
 #[derive(Debug)]
 enum BindingOrValue {
-    Identifier(Identifier, Option<NodeId>, Location),
+    Identifier(Name, Option<NodeId>, Location),
     Binding(NodeId),
     Value(NodeId),
 }
@@ -615,7 +615,7 @@ impl<'toks, T: Iterator<Item = &'toks Token>> ParseState<'_, 'toks, T> {
         Ok(left)
     }
 
-    fn name(&mut self, res: Token) -> Identifier {
+    fn name(&mut self, res: Token) -> Name {
         assert!(res.kind == TokenType::Ident);
         let name = res.get_src(self.contents);
         trace!("Name: {name}");
@@ -700,7 +700,7 @@ pub fn parse(filepath: &Path, ast: &Option<Ast>, contents: &str, tokens: &[Token
     Ok(state.ast)
 }
 
-fn normalize_keywords_as_ops(ast: &Ast, name: Identifier) -> TokenType {
+fn normalize_keywords_as_ops(ast: &Ast, name: Name) -> TokenType {
     let interner = &ast.string_interner;
     let op = if name == interner.kw_lambda {
         Symbol::Lambda

--- a/takolib/src/parser/mod.rs
+++ b/takolib/src/parser/mod.rs
@@ -671,7 +671,12 @@ impl<'toks, T: Iterator<Item = &'toks Token>> ParseState<'_, 'toks, T> {
     }
 }
 
-pub fn parse(filepath: &Path, ast: &Option<Ast>, contents: &str, tokens: &[Token]) -> Result<Ast, TError> {
+pub fn parse(
+    filepath: &Path,
+    ast: &Option<Ast>,
+    contents: &str,
+    tokens: &[Token],
+) -> Result<Ast, TError> {
     trace!("Parse {}: {:?}", filepath.display(), &tokens);
     let ast = if let Some(ast) = ast {
         ast.clone()
@@ -730,7 +735,7 @@ pub mod tests {
     fn setup(s: &str) -> Result<Ast, TError> {
         crate::ensure_initialized();
         let tokens = lex(s)?;
-        parse(&test_file1(), s, &tokens)
+        parse(&test_file1(), &None, s, &tokens)
     }
 
     #[test]

--- a/takolib/src/tasks/mod.rs
+++ b/takolib/src/tasks/mod.rs
@@ -48,7 +48,7 @@ pub enum AnyTask {
 pub enum RequestTask {
     Build { files: Vec<PathBuf> },
     RunInterpreter { files: Vec<PathBuf> },
-    EvalLine(String),
+    Eval { ast: Ast /* Holding all context and state */, expr: String },
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -107,6 +107,7 @@ impl Task for LexFileTask {
         let tokens = tokens
             .map(|tokens| ParseFileTask {
                 path: self.path.clone(),
+                ast: None,
                 contents: self.contents.clone(),
                 tokens,
             })
@@ -126,6 +127,7 @@ impl Task for LexFileTask {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ParseFileTask {
     pub path: PathBuf,
+    pub ast: Option<Ast>,
     pub contents: String,
     pub tokens: Vec<Token>,
 }
@@ -140,7 +142,7 @@ impl Task for ParseFileTask {
     }
     async fn perform(self, result_sender: UpdateSenderFor<Self>) {
         trace!("ParseFileTask: {path}", path = self.path.display());
-        let ast = crate::parser::parse(&self.path, &self.contents, &self.tokens)
+        let ast = crate::parser::parse(&self.path, &self.ast, &self.contents, &self.tokens)
             .map_err(|err| self.decorate_error(err));
         result_sender
             .send((
@@ -251,7 +253,7 @@ impl Task for EvalFileTask {
     }
     async fn perform(self, result_sender: UpdateSenderFor<Self>) {
         trace!("EvalFileTask: {path}", path = self.path.display());
-        let result = crate::interpreter::run(&self.path, &self.ast, self.root)
+        let result = crate::interpreter::run(&self.path, &self.ast, &self.ast, self.root)
             .map_err(|err| self.decorate_error(err));
         result_sender
             .send((

--- a/takolib/src/tasks/mod.rs
+++ b/takolib/src/tasks/mod.rs
@@ -48,7 +48,7 @@ pub enum AnyTask {
 pub enum RequestTask {
     Build { files: Vec<PathBuf> },
     RunInterpreter { files: Vec<PathBuf> },
-    Eval { ast: Ast /* Holding all context and state */, expr: String },
+    Eval { ast: Option<Ast> /* Holding all context and state */, expr: String },
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -253,7 +253,7 @@ impl Task for EvalFileTask {
     }
     async fn perform(self, result_sender: UpdateSenderFor<Self>) {
         trace!("EvalFileTask: {path}", path = self.path.display());
-        let result = crate::interpreter::run(&self.path, &self.ast, &self.ast, self.root)
+        let result = crate::interpreter::run(&self.path, self.ast.clone(), self.root)
             .map_err(|err| self.decorate_error(err));
         result_sender
             .send((

--- a/takolib/src/tasks/mod.rs
+++ b/takolib/src/tasks/mod.rs
@@ -46,9 +46,16 @@ pub enum AnyTask {
 /// There's normally only one of these, but it seems elegant to have these fit into the `Task` model.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RequestTask {
-    Build { files: Vec<PathBuf> },
-    RunInterpreter { files: Vec<PathBuf> },
-    Eval { ast: Option<Ast> /* Holding all context and state */, expr: String },
+    Build {
+        files: Vec<PathBuf>,
+    },
+    RunInterpreter {
+        files: Vec<PathBuf>,
+    },
+    Eval {
+        ast: Option<Ast>, /* Holding all context and state */
+        expr: String,
+    },
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/takolib/src/test.rs
+++ b/takolib/src/test.rs
@@ -85,7 +85,7 @@ fn parse_example_files(file: PathBuf) {
     };
 
     // TODO: Macro or helper?
-    let _ast = match crate::parser::parse(&file, &contents, &tokens) {
+    let _ast = match crate::parser::parse(&file, &None, &contents, &tokens) {
         Err(e) => {
             assert_eq!(
                 setting.expect,

--- a/takolib/src/ui/client.rs
+++ b/takolib/src/ui/client.rs
@@ -72,7 +72,7 @@ impl Client {
     }
 
     pub fn send_command(&mut self, cmd: RequestTask) {
-        if let RequestTask::EvalLine(line) = &cmd {
+        if let RequestTask::Eval(line) = &cmd {
             self.history.push(line.to_string());
         }
         self.request_sender

--- a/takolib/src/ui/client.rs
+++ b/takolib/src/ui/client.rs
@@ -72,8 +72,8 @@ impl Client {
     }
 
     pub fn send_command(&mut self, cmd: RequestTask) {
-        if let RequestTask::Eval(line) = &cmd {
-            self.history.push(line.to_string());
+        if let RequestTask::Eval { ast: _, expr: line } = &cmd {
+            self.history.push(line.to_string()); // Maybe assumes a single line?
         }
         self.request_sender
             .send((cmd, self.result_sender.clone()))

--- a/takoweb/src/client.rs
+++ b/takoweb/src/client.rs
@@ -55,7 +55,10 @@ pub async fn interpret(src: &str) -> String {
         .send((tx, Box::<Options>::default()))
         .expect("Send client request failed");
     let mut client = rx.await.expect("Get client failed");
-    client.send_command(RequestTask::Eval(src.to_string()));
+    client.send_command(RequestTask::Eval {
+        ast: None,
+        expr: src.to_string(),
+    });
     let result = client.result_receiver.recv();
     if let Some(result) = result.await {
         result.to_string()

--- a/takoweb/src/client.rs
+++ b/takoweb/src/client.rs
@@ -55,7 +55,7 @@ pub async fn interpret(src: &str) -> String {
         .send((tx, Box::<Options>::default()))
         .expect("Send client request failed");
     let mut client = rx.await.expect("Get client failed");
-    client.send_command(RequestTask::EvalLine(src.to_string()));
+    client.send_command(RequestTask::Eval(src.to_string()));
     let result = client.result_receiver.recv();
     if let Some(result) = result.await {
         result.to_string()


### PR DESCRIPTION
- **TMP - modified**
- **Pass Ast 'context' through Eval Requests to allow interactive interpreter runs**
